### PR TITLE
Added Dynamic Entities for ChannelNames + More Dialog Management

### DIFF
--- a/lambda/custom/apiEndpoints.js
+++ b/lambda/custom/apiEndpoints.js
@@ -10,6 +10,7 @@ const { serverurl } = envVariables;
 module.exports = {
 	loginUrl: `${ serverurl }/api/v1/login`,
 	meUrl: `${ serverurl }/api/v1/me`,
+	channellisturl: `${ serverurl }/api/v1/channels.list.joined`,
 	createchannelurl: `${ serverurl }/api/v1/channels.create`,
 	deletechannelurl: `${ serverurl }/api/v1/channels.delete`,
 	postmessageurl: `${ serverurl }/api/v1/chat.postMessage`,

--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -553,10 +553,10 @@ function getStaticAndDynamicSlotValuesFromSlot(slot) {
 	}
 	
 	if(result.hasOwnProperty('dynamic') && result.dynamic.statusCode === 'ER_SUCCESS_MATCH'){
-		return result.dynamic.resolvedValues[0];
+		return result.dynamic.resolvedValues[0].value.name;
 	}
-	else if(result.hasOwnProperty('static') && result.dynamic.statusCode === 'ER_SUCCESS_MATCH'){
-		return result.static.resolvedValues[0];
+	else if(result.hasOwnProperty('static') && result.static.statusCode === 'ER_SUCCESS_MATCH'){
+		return result.static.resolvedValues[0].value.name;
 	}
 	else{
 		return result.value;

--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -100,6 +100,23 @@ const removePersonalAccessToken = async (headers) =>
 		return "";
 	});
 
+const channelList = async (headers) =>
+	await axios
+	.get(`${ apiEndpoints.channellisturl }?fields={ "name": 1 }&sort={"_updatedAt":-1}&count=100`, {
+		headers
+	})
+	.then((res) => res.data)
+	.then(res => {
+		return res.channels.map(i => ({
+			"name": {
+				"value": i.name
+			}
+		}));
+	})
+	.catch((err) => {
+		console.log(err.message);
+	});
+
 const createChannel = async (channelName, headers) =>
 	await axios
 	.post(
@@ -503,6 +520,49 @@ function slotValue(slot) {
 	return value;
 }
 
+function getStaticAndDynamicSlotValuesFromSlot(slot) {
+    
+    const result = {
+        name: slot.name,
+        value: slot.value
+    };
+    
+    if (((slot.resolutions || {}).resolutionsPerAuthority || [])[0] || {}) {
+        slot.resolutions.resolutionsPerAuthority.forEach((authority) => {
+            const slotValue = {
+                authority: authority.authority,
+                statusCode: authority.status.code,
+                synonym: slot.value || undefined,
+                resolvedValues: slot.value
+            };
+            if (authority.values && authority.values.length > 0) {
+                slotValue.resolvedValues = [];
+                
+                authority.values.forEach((value) => {
+                    slotValue.resolvedValues.push(value);
+                });
+                
+            }
+            
+            if (authority.authority.includes('amzn1.er-authority.echo-sdk.dynamic')) {
+                result.dynamic = slotValue;
+            } else {
+                result.static = slotValue;
+            }
+        });
+	}
+	
+	if(result.hasOwnProperty('dynamic') && result.dynamic.statusCode === 'ER_SUCCESS_MATCH'){
+		return result.dynamic.resolvedValues[0];
+	}
+	else if(result.hasOwnProperty('static') && result.dynamic.statusCode === 'ER_SUCCESS_MATCH'){
+		return result.static.resolvedValues[0];
+	}
+	else{
+		return result.value;
+	}
+};
+
 const createGroup = async (channelName, headers) =>
 	await axios
 	.post(
@@ -813,6 +873,7 @@ const postDirectMessage = async (message, roomid, headers) =>
 
 module.exports.login = login;
 module.exports.createPersonalAccessToken = createPersonalAccessToken;
+module.exports.channelList = channelList;
 module.exports.createChannel = createChannel;
 module.exports.deleteChannel = deleteChannel;
 module.exports.postMessage = postMessage;
@@ -833,6 +894,7 @@ module.exports.replaceWhitespacesDots = replaceWhitespacesDots;
 module.exports.emojiTranslateFunc = emojiTranslateFunc;
 module.exports.readMessages = readMessages;
 module.exports.slotValue = slotValue;
+module.exports.getStaticAndDynamicSlotValuesFromSlot = getStaticAndDynamicSlotValuesFromSlot;
 module.exports.createGroup = createGroup;
 module.exports.deleteGroup = deleteGroup;
 module.exports.getGroupId = getGroupId;

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -420,10 +420,67 @@ const CreateChannelIntentHandler = {
 	},
 };
 
+const StartedDeleteChannelIntentHandler = {
+  canHandle(handlerInput) {
+    return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
+      handlerInput.requestEnvelope.request.intent.name === 'DeleteChannelIntent' &&
+      handlerInput.requestEnvelope.request.dialogState === 'STARTED';
+  },
+  handle(handlerInput) {
+    const currentIntent = handlerInput.requestEnvelope.request.intent;
+    return handlerInput.responseBuilder
+      .addDelegateDirective(currentIntent)
+      .getResponse();
+  },
+};
+
+const InProgressDeleteChannelIntentHandler = {
+  canHandle(handlerInput) {
+    return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
+      handlerInput.requestEnvelope.request.intent.name === 'DeleteChannelIntent' &&
+      handlerInput.requestEnvelope.request.dialogState === 'IN_PROGRESS' &&
+	  handlerInput.requestEnvelope.request.intent.confirmationStatus !== 'DENIED';
+  },
+  handle(handlerInput) {
+    const currentIntent = handlerInput.requestEnvelope.request.intent;
+    return handlerInput.responseBuilder
+      .addDelegateDirective(currentIntent)
+      .getResponse();
+  },
+};
+
+const DeniedDeleteChannelIntentHandler = {
+	canHandle(handlerInput) {
+	  return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
+		handlerInput.requestEnvelope.request.intent.name === 'DeleteChannelIntent' &&
+		handlerInput.requestEnvelope.request.dialogState === 'IN_PROGRESS' &&
+		handlerInput.requestEnvelope.request.intent.confirmationStatus === 'DENIED';
+	},
+	handle(handlerInput) {
+		let speechText = ri('DELETE_CHANNEL.DENIED');
+
+		return handlerInput.jrb
+		  .speak(speechText)
+		  .addDelegateDirective({
+			name: 'DeleteChannelIntent',
+			confirmationStatus: 'NONE',
+			slots: {
+				"channeldelete": {
+					"name": "channeldelete",
+					"confirmationStatus": "NONE"
+				}
+			}
+		  })
+		  .getResponse();
+	},
+};
+
 const DeleteChannelIntentHandler = {
 	canHandle(handlerInput) {
 		return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
-			handlerInput.requestEnvelope.request.intent.name === 'DeleteChannelIntent';
+			handlerInput.requestEnvelope.request.intent.name === 'DeleteChannelIntent'
+			&& handlerInput.requestEnvelope.request.dialogState === 'COMPLETED'
+			&& handlerInput.requestEnvelope.request.intent.confirmationStatus === 'CONFIRMED';
 	},
 	async handle(handlerInput) {
 		try {
@@ -1254,6 +1311,9 @@ exports.handler = skillBuilder
 		InProgressCreateChannelIntentHandler,
 		DeniedCreateChannelIntentHandler,
 		CreateChannelIntentHandler,
+		StartedDeleteChannelIntentHandler,
+		InProgressDeleteChannelIntentHandler,
+		DeniedDeleteChannelIntentHandler,
 		DeleteChannelIntentHandler,
 		StartedPostMessageIntentHandler,
 		InProgressPostMessageIntentHandler,

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -197,6 +197,16 @@ const LaunchRequestHandler = {
 					}
 				}
 			})
+			.addDirective({
+				type: 'Dialog.UpdateDynamicEntities',
+				updateBehavior: 'REPLACE',
+				types: [
+				  {
+					name: 'channelnames',
+					values: await helperFunctions.channelList(headers)
+				  }
+				]
+			})
 			.getResponse();
 
 		} else {

--- a/lambda/custom/resources/en-AU.json
+++ b/lambda/custom/resources/en-AU.json
@@ -47,7 +47,8 @@
         "AUTH_ERROR": "Sorry you are currently signed out , please use the companion app to authenticate ",
         "CARD_TITLE": "Delete A Channel",
         "ERROR": "Sorry, I couldn't delete the channel {channelName} right now.",
-        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name."
+        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name.",
+        "DENIED": "Okay, let's try again."
     },
     "GET_LAST_MESSAGE_FROM_CHANNEL": {
         "SUCCESS": "{name} says, {message}.",

--- a/lambda/custom/resources/en-CA.json
+++ b/lambda/custom/resources/en-CA.json
@@ -47,7 +47,8 @@
         "AUTH_ERROR": "Sorry you are currently signed out , please use the companion app to authenticate ",
         "CARD_TITLE": "Delete A Channel",
         "ERROR": "Sorry, I couldn't delete the channel {channelName} right now.",
-        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name."
+        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name.",
+        "DENIED": "Okay, let's try again."
     },
     "GET_LAST_MESSAGE_FROM_CHANNEL": {
         "SUCCESS": "{name} says, {message}.",

--- a/lambda/custom/resources/en-GB.json
+++ b/lambda/custom/resources/en-GB.json
@@ -47,7 +47,8 @@
         "AUTH_ERROR": "Sorry you are currently signed out , please use the companion app to authenticate ",
         "CARD_TITLE": "Delete A Channel",
         "ERROR": "Sorry, I couldn't delete the channel {channelName} right now.",
-        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name."
+        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name.",
+        "DENIED": "Okay, let's try again."
     },
     "GET_LAST_MESSAGE_FROM_CHANNEL": {
         "SUCCESS": "{name} says, {message}.",

--- a/lambda/custom/resources/en-IN.json
+++ b/lambda/custom/resources/en-IN.json
@@ -47,7 +47,8 @@
         "AUTH_ERROR": "Sorry you are currently signed out , please use the companion app to authenticate ",
         "CARD_TITLE": "Delete A Channel",
         "ERROR": "Sorry, I couldn't delete the channel {channelName} right now.",
-        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name."
+        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name.",
+        "DENIED": "Okay, let's try again."
     },
     "GET_LAST_MESSAGE_FROM_CHANNEL": {
         "SUCCESS": "{name} says, {message}.",

--- a/lambda/custom/resources/en-US.json
+++ b/lambda/custom/resources/en-US.json
@@ -47,7 +47,8 @@
         "AUTH_ERROR": "Sorry you are currently signed out , please use the companion app to authenticate ",
         "CARD_TITLE": "Delete A Channel",
         "ERROR": "Sorry, I couldn't delete the channel {channelName} right now.",
-        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name."
+        "ERROR_NOT_FOUND": "Sorry, the channel {channelName} does not exist. Please try again with different channel name.",
+        "DENIED": "Okay, let's try again."
     },
     "GET_LAST_MESSAGE_FROM_CHANNEL": {
         "SUCCESS": "{name} says, {message}.",

--- a/models/en-AU.json
+++ b/models/en-AU.json
@@ -50,10 +50,18 @@
                     "slots": [
                         {
                             "name": "channeldelete",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "delete {channeldelete}",
+                                "{channeldelete}",
+                                "delete channel {channeldelete}",
+                                "delete room {channeldelete}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "delete room",
+                        "delete channel",
                         "delete room {channeldelete}",
                         "delete channel {channeldelete}",
                         "delete {channeldelete}"
@@ -1692,6 +1700,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "DeleteChannelIntent",
+                    "confirmationRequired": true,
+                    "prompts": {
+                        "confirmation": "Confirm.Intent.1279935591703"
+                    },
+                    "slots": [
+                        {
+                            "name": "channeldelete",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.1279935591703.1198344949986"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1757,6 +1783,24 @@
                     {
                         "type": "PlainText",
                         "value": "You want to create channel {channelname} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Confirm.Intent.1279935591703",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "You want to delete channel {channeldelete} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.1279935591703.1198344949986",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel do you want to delete?"
                     }
                 ]
             }

--- a/models/en-AU.json
+++ b/models/en-AU.json
@@ -99,10 +99,21 @@
                     "slots": [
                         {
                             "name": "getmessagechannelname",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "latest message from {getmessagechannelname}",
+                                "read latest message in {getmessagechannelname}",
+                                "read last message from {getmessagechannelname}",
+                                "from {getmessagechannelname}",
+                                "{getmessagechannelname}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "what is the latest message",
+                        "what is the latest message in {getmessagechannelname}",
+                        "read latest message",
+                        "read last message",
                         "latest message from {getmessagechannelname}",
                         "read last message from {getmessagechannelname}",
                         "read latest message in {getmessagechannelname}",
@@ -1718,6 +1729,23 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "GetLastMessageFromChannelIntent",
+                    "delegationStrategy": "ALWAYS",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                        {
+                            "name": "getmessagechannelname",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.449336420378.1492444758346"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1801,6 +1829,15 @@
                     {
                         "type": "PlainText",
                         "value": "Which channel do you want to delete?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.449336420378.1492444758346",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel's last message do you want to hear?"
                     }
                 ]
             }

--- a/models/en-CA.json
+++ b/models/en-CA.json
@@ -50,10 +50,18 @@
                     "slots": [
                         {
                             "name": "channeldelete",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "delete {channeldelete}",
+                                "{channeldelete}",
+                                "delete channel {channeldelete}",
+                                "delete room {channeldelete}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "delete room",
+                        "delete channel",
                         "delete room {channeldelete}",
                         "delete channel {channeldelete}",
                         "delete {channeldelete}"
@@ -1692,6 +1700,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "DeleteChannelIntent",
+                    "confirmationRequired": true,
+                    "prompts": {
+                        "confirmation": "Confirm.Intent.1279935591703"
+                    },
+                    "slots": [
+                        {
+                            "name": "channeldelete",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.1279935591703.1198344949986"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1757,6 +1783,24 @@
                     {
                         "type": "PlainText",
                         "value": "You want to create channel {channelname} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Confirm.Intent.1279935591703",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "You want to delete channel {channeldelete} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.1279935591703.1198344949986",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel do you want to delete?"
                     }
                 ]
             }

--- a/models/en-CA.json
+++ b/models/en-CA.json
@@ -99,10 +99,21 @@
                     "slots": [
                         {
                             "name": "getmessagechannelname",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "latest message from {getmessagechannelname}",
+                                "read latest message in {getmessagechannelname}",
+                                "read last message from {getmessagechannelname}",
+                                "from {getmessagechannelname}",
+                                "{getmessagechannelname}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "what is the latest message",
+                        "what is the latest message in {getmessagechannelname}",
+                        "read latest message",
+                        "read last message",
                         "latest message from {getmessagechannelname}",
                         "read last message from {getmessagechannelname}",
                         "read latest message in {getmessagechannelname}",
@@ -1718,6 +1729,23 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "GetLastMessageFromChannelIntent",
+                    "delegationStrategy": "ALWAYS",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                        {
+                            "name": "getmessagechannelname",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.449336420378.1492444758346"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1801,6 +1829,15 @@
                     {
                         "type": "PlainText",
                         "value": "Which channel do you want to delete?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.449336420378.1492444758346",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel's last message do you want to hear?"
                     }
                 ]
             }

--- a/models/en-GB.json
+++ b/models/en-GB.json
@@ -50,10 +50,18 @@
                     "slots": [
                         {
                             "name": "channeldelete",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "delete {channeldelete}",
+                                "{channeldelete}",
+                                "delete channel {channeldelete}",
+                                "delete room {channeldelete}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "delete room",
+                        "delete channel",
                         "delete room {channeldelete}",
                         "delete channel {channeldelete}",
                         "delete {channeldelete}"
@@ -1692,6 +1700,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "DeleteChannelIntent",
+                    "confirmationRequired": true,
+                    "prompts": {
+                        "confirmation": "Confirm.Intent.1279935591703"
+                    },
+                    "slots": [
+                        {
+                            "name": "channeldelete",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.1279935591703.1198344949986"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1757,6 +1783,24 @@
                     {
                         "type": "PlainText",
                         "value": "You want to create channel {channelname} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Confirm.Intent.1279935591703",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "You want to delete channel {channeldelete} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.1279935591703.1198344949986",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel do you want to delete?"
                     }
                 ]
             }

--- a/models/en-GB.json
+++ b/models/en-GB.json
@@ -99,10 +99,21 @@
                     "slots": [
                         {
                             "name": "getmessagechannelname",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "latest message from {getmessagechannelname}",
+                                "read latest message in {getmessagechannelname}",
+                                "read last message from {getmessagechannelname}",
+                                "from {getmessagechannelname}",
+                                "{getmessagechannelname}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "what is the latest message",
+                        "what is the latest message in {getmessagechannelname}",
+                        "read latest message",
+                        "read last message",
                         "latest message from {getmessagechannelname}",
                         "read last message from {getmessagechannelname}",
                         "read latest message in {getmessagechannelname}",
@@ -1718,6 +1729,23 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "GetLastMessageFromChannelIntent",
+                    "delegationStrategy": "ALWAYS",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                        {
+                            "name": "getmessagechannelname",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.449336420378.1492444758346"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1801,6 +1829,15 @@
                     {
                         "type": "PlainText",
                         "value": "Which channel do you want to delete?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.449336420378.1492444758346",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel's last message do you want to hear?"
                     }
                 ]
             }

--- a/models/en-IN.json
+++ b/models/en-IN.json
@@ -50,10 +50,18 @@
                     "slots": [
                         {
                             "name": "channeldelete",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "delete {channeldelete}",
+                                "{channeldelete}",
+                                "delete channel {channeldelete}",
+                                "delete room {channeldelete}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "delete room",
+                        "delete channel",
                         "delete room {channeldelete}",
                         "delete channel {channeldelete}",
                         "delete {channeldelete}"
@@ -1692,6 +1700,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "DeleteChannelIntent",
+                    "confirmationRequired": true,
+                    "prompts": {
+                        "confirmation": "Confirm.Intent.1279935591703"
+                    },
+                    "slots": [
+                        {
+                            "name": "channeldelete",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.1279935591703.1198344949986"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1757,6 +1783,24 @@
                     {
                         "type": "PlainText",
                         "value": "You want to create channel {channelname} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Confirm.Intent.1279935591703",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "You want to delete channel {channeldelete} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.1279935591703.1198344949986",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel do you want to delete?"
                     }
                 ]
             }

--- a/models/en-IN.json
+++ b/models/en-IN.json
@@ -99,10 +99,21 @@
                     "slots": [
                         {
                             "name": "getmessagechannelname",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "latest message from {getmessagechannelname}",
+                                "read latest message in {getmessagechannelname}",
+                                "read last message from {getmessagechannelname}",
+                                "from {getmessagechannelname}",
+                                "{getmessagechannelname}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "what is the latest message",
+                        "what is the latest message in {getmessagechannelname}",
+                        "read latest message",
+                        "read last message",
                         "latest message from {getmessagechannelname}",
                         "read last message from {getmessagechannelname}",
                         "read latest message in {getmessagechannelname}",
@@ -1718,6 +1729,23 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "GetLastMessageFromChannelIntent",
+                    "delegationStrategy": "ALWAYS",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                        {
+                            "name": "getmessagechannelname",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.449336420378.1492444758346"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1801,6 +1829,15 @@
                     {
                         "type": "PlainText",
                         "value": "Which channel do you want to delete?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.449336420378.1492444758346",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel's last message do you want to hear?"
                     }
                 ]
             }

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -50,10 +50,18 @@
                     "slots": [
                         {
                             "name": "channeldelete",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "delete {channeldelete}",
+                                "{channeldelete}",
+                                "delete channel {channeldelete}",
+                                "delete room {channeldelete}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "delete room",
+                        "delete channel",
                         "delete room {channeldelete}",
                         "delete channel {channeldelete}",
                         "delete {channeldelete}"
@@ -1692,6 +1700,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "DeleteChannelIntent",
+                    "confirmationRequired": true,
+                    "prompts": {
+                        "confirmation": "Confirm.Intent.1279935591703"
+                    },
+                    "slots": [
+                        {
+                            "name": "channeldelete",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.1279935591703.1198344949986"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1757,6 +1783,24 @@
                     {
                         "type": "PlainText",
                         "value": "You want to create channel {channelname} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Confirm.Intent.1279935591703",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "You want to delete channel {channeldelete} . Is that correct?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.1279935591703.1198344949986",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel do you want to delete?"
                     }
                 ]
             }

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -99,10 +99,21 @@
                     "slots": [
                         {
                             "name": "getmessagechannelname",
-                            "type": "channelnames"
+                            "type": "channelnames",
+                            "samples": [
+                                "latest message from {getmessagechannelname}",
+                                "read latest message in {getmessagechannelname}",
+                                "read last message from {getmessagechannelname}",
+                                "from {getmessagechannelname}",
+                                "{getmessagechannelname}"
+                            ]
                         }
                     ],
                     "samples": [
+                        "what is the latest message",
+                        "what is the latest message in {getmessagechannelname}",
+                        "read latest message",
+                        "read last message",
                         "latest message from {getmessagechannelname}",
                         "read last message from {getmessagechannelname}",
                         "read latest message in {getmessagechannelname}",
@@ -1718,6 +1729,23 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "GetLastMessageFromChannelIntent",
+                    "delegationStrategy": "ALWAYS",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                        {
+                            "name": "getmessagechannelname",
+                            "type": "channelnames",
+                            "confirmationRequired": false,
+                            "elicitationRequired": true,
+                            "prompts": {
+                                "elicitation": "Elicit.Slot.449336420378.1492444758346"
+                            }
+                        }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1801,6 +1829,15 @@
                     {
                         "type": "PlainText",
                         "value": "Which channel do you want to delete?"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.449336420378.1492444758346",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel's last message do you want to hear?"
                     }
                 ]
             }


### PR DESCRIPTION
Dynamic Entities have been added to Channel Names.
Right now it is implemented in PostMessageIntent to provide better recognition of channel name when the user says, "Alexa, send {message} to {channelName}".

Dialog Management has been added to a couple more intents. More to follow.