### PR TITLE
[Improvement] PostMessageIntent able to handle both public and private channel requests

### DIFF
--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -733,33 +733,6 @@ const addGroupOwner = async (userName, channelName, userid, roomid, headers) =>
 		}
 	});
 
-const postGroupMessage = async (roomid, message, headers) =>
-	await axios
-	.post(
-		apiEndpoints.postmessageurl, {
-			roomId: roomid,
-			text: message,
-		}, {
-			headers
-		}
-	)
-	.then((res) => res.data)
-	.then((res) => {
-		if (res.success === true) {
-			return ri('POST_MESSAGE.SUCCESS');
-		} else {
-			return ri('POST_MESSAGE.ERROR');
-		}
-	})
-	.catch((err) => {
-		console.log(err.message);
-		if (err.response.status === 401) {
-			return ri('POST_MESSAGE.AUTH_ERROR');
-		} else {
-			return ri('POST_MESSAGE.ERROR');
-		}
-	});
-
 const groupLastMessage = async (channelName, roomid, headers) =>
 	await axios
 	.get(`${ apiEndpoints.groupmessageurl }${ roomid }`, {
@@ -864,30 +837,6 @@ const createDMSession = async (userName, headers) =>
 		console.log(err.message);
 	});
 
-const postDirectMessage = async (message, roomid, headers) =>
-	await axios
-	.post(
-		apiEndpoints.postmessageurl, {
-			roomId: roomid,
-			text: message,
-		}, {
-			headers
-		}
-	)
-	.then((res) => res.data)
-	.then((res) => {
-		if (res.success === true) {
-			return ri('POST_MESSAGE.SUCCESS');
-		} else {
-			return ri('POST_MESSAGE.ERROR');
-		}
-	})
-	.catch((err) => {
-		console.log(err.message);
-		return ri('POST_MESSAGE.ERROR');
-	});
-
-
 // Module Export of Functions
 
 module.exports.login = login;
@@ -919,10 +868,8 @@ module.exports.deleteGroup = deleteGroup;
 module.exports.getGroupId = getGroupId;
 module.exports.addGroupModerator = addGroupModerator;
 module.exports.addGroupOwner = addGroupOwner;
-module.exports.postGroupMessage = postGroupMessage;
 module.exports.groupLastMessage = groupLastMessage;
 module.exports.getGroupUnreadCounter = getGroupUnreadCounter;
 module.exports.groupUnreadMessages = groupUnreadMessages;
 module.exports.createDMSession = createDMSession;
-module.exports.postDirectMessage = postDirectMessage;
 module.exports.getLastMessageType = getLastMessageType;

--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -197,11 +197,11 @@ const deleteChannel = async (channelName, headers) =>
 		}
 	});
 
-const postMessage = async (channelName, message, headers) =>
+const postMessage = async (roomid, message, headers) =>
 	await axios
 	.post(
 		apiEndpoints.postmessageurl, {
-			channel: `#${ channelName }`,
+			roomId: roomid,
 			text: message,
 		}, {
 			headers

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -1607,7 +1607,7 @@ const PostGroupMessageIntentHandler = {
 
 			const headers = await helperFunctions.login(accessToken);
 			const roomid = await helperFunctions.getGroupId(channelName, headers);
-			const speechText = await helperFunctions.postGroupMessage(roomid, message, headers);
+			const speechText = await helperFunctions.postMessage(roomid, message, headers);
 			let repromptText = ri('GENERIC_REPROMPT');
 
 
@@ -1643,7 +1643,7 @@ const PostGroupEmojiMessageIntentHandler = {
 
 			const headers = await helperFunctions.login(accessToken);
 			const roomid = await helperFunctions.getGroupId(channelName, headers);
-			const speechText = await helperFunctions.postGroupMessage(roomid, message, headers);
+			const speechText = await helperFunctions.postMessage(roomid, message, headers);
 			let repromptText = ri('GENERIC_REPROMPT');
 
 
@@ -1740,7 +1740,7 @@ const PostDirectMessageIntentHandler = {
 
 			const headers = await helperFunctions.login(accessToken);
 			const roomid = await helperFunctions.createDMSession(userName, headers);
-			const speechText = await helperFunctions.postDirectMessage(message, roomid, headers);
+			const speechText = await helperFunctions.postMessage(roomid, message, headers);
 			let repromptText = ri('GENERIC_REPROMPT');
 
 
@@ -1776,7 +1776,7 @@ const PostEmojiDirectMessageIntentHandler = {
 
 			const headers = await helperFunctions.login(accessToken);
 			const roomid = await helperFunctions.createDMSession(userName, headers);
-			const speechText = await helperFunctions.postDirectMessage(message, roomid, headers);
+			const speechText = await helperFunctions.postMessage(roomid, message, headers);
 			let repromptText = ri('GENERIC_REPROMPT');
 
 

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -667,7 +667,13 @@ const PostMessageIntentHandler = {
 			const channelName = helperFunctions.replaceWhitespacesFunc(channelNameData);
 
 			const headers = await helperFunctions.login(accessToken);
-			const speechText = await helperFunctions.postMessage(channelName, message, headers);
+
+			let roomid = await helperFunctions.getGroupId(channelName, headers);
+			if(!roomid){
+				roomid = await helperFunctions.getRoomId(channelName, headers);
+			}
+
+			const speechText = await helperFunctions.postMessage(roomid, message, headers);
 			let repromptText = ri('GENERIC_REPROMPT');
 
 
@@ -866,7 +872,8 @@ const NoIntentHandler = {
 			delete sessionAttributes.message;
 
 			const headers = await helperFunctions.login(accessToken);
-			const speechText = await helperFunctions.postMessage(channelName, message, headers);
+			let roomid = await helperFunctions.getRoomId(channelName, headers);
+			const speechText = await helperFunctions.postMessage(roomid, message, headers);
 			let repromptText = ri('GENERIC_REPROMPT');
 
 
@@ -955,7 +962,13 @@ const PostEmojiMessageIntentHandler = {
 			const message = messageData + emoji;
 
 			const headers = await helperFunctions.login(accessToken);
-			const speechText = await helperFunctions.postMessage(channelName, message, headers);
+
+			let roomid = await helperFunctions.getGroupId(channelName, headers);
+			if(!roomid){
+				roomid = await helperFunctions.getRoomId(channelName, headers);
+			}
+
+			const speechText = await helperFunctions.postMessage(roomid, message, headers);
 			let repromptText = ri('GENERIC_REPROMPT');
 
 			return handlerInput.jrb


### PR DESCRIPTION
This branch let's PostMessageIntent to be used for both public and private channel requests.
It uses a simple logical block and uses the following helper functions:-
* `getRoomId` (returns roomId of a channel if the argument passed is name of a channel, undefined otherwise)
* `getGroupId` (returns roomId of a group if the argument passed is name of a group, undefined otherwise)  

It first checks if the channel is private, if it's not private it checks if it's public and then sends a message using `postMessage(roomid, message, headers)` method.

Additionally all the post message related requests are achieved using a single helper function `postMessage(roomid, message, headers)`. 
`postGroupMessage` and `postDirectMessage` functions are removed since they are no longer required.


Affected Intents:

- PostMessageIntent
- PostEmojiMessageIntent
- PostGroupMessageIntent
- PostGroupEmojiMessageIntent
- PostDirectMessageIntent
- PostEmojiDirectMessageIntent
