### PR TITLE
[FIX] fixing declaration of an undeclared variable

### DIFF
--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -525,7 +525,7 @@ function replaceWhitespacesDots(str) {
 }
 
 function emojiTranslateFunc(str) {
-	onlyEmoji = true;
+	const onlyEmoji = true;
 	return emojiTranslate.translate(str, onlyEmoji);
 }
 


### PR DESCRIPTION
Declaring a variable which wasn't declared before usage