### PR TITLE
[Improvement] Using string similarity to resolve usernames

### DIFF
--- a/lambda/custom/apiEndpoints.js
+++ b/lambda/custom/apiEndpoints.js
@@ -35,4 +35,5 @@ module.exports = {
 	groupmessageurl: `${ serverurl }/api/v1/groups.messages?roomId=`,
 	groupcounterurl: `${ serverurl }/api/v1/groups.counters?roomId=`,
 	createimurl: `${ serverurl }/api/v1/im.create`,
+	userslisturl: `${serverurl}/api/v1/users.list`,
 };

--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -9,6 +9,7 @@ const {
 
 const removeWhitespace = require('remove-whitespace');
 const emojiTranslate = require('moji-translate');
+const stringSimilar = require('string-similarity')
 
 // Server Credentials. Follow readme to set them up.
 const {
@@ -529,6 +530,19 @@ function emojiTranslateFunc(str) {
 	return emojiTranslate.translate(str, onlyEmoji);
 }
 
+const resolveUsername = async (userNameData, headers) =>
+	await axios
+	.get(apiEndpoints.userslisturl, {
+		headers
+	})
+	.then((res) => res.data.users)
+    .then((res) => {
+        const usernames = res.map(data => data.username);
+		username = stringSimilar.findBestMatch(userNameData, usernames).bestMatch
+		if(username.rating >= 0.3) return username.target
+		return userNameData
+    })
+
 function slotValue(slot) {
 	let value = slot.value;
 	let resolution = (slot.resolutions && slot.resolutions.resolutionsPerAuthority && slot.resolutions.resolutionsPerAuthority.length > 0) ? slot.resolutions.resolutionsPerAuthority[0] : null;
@@ -926,3 +940,4 @@ module.exports.groupUnreadMessages = groupUnreadMessages;
 module.exports.createDMSession = createDMSession;
 module.exports.postDirectMessage = postDirectMessage;
 module.exports.getLastMessageType = getLastMessageType;
+module.exports.resolveUsername = resolveUsername;

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -1723,9 +1723,9 @@ const PostDirectMessageIntentHandler = {
 
 			let message = handlerInput.requestEnvelope.request.intent.slots.directmessage.value;
 			const userNameData = handlerInput.requestEnvelope.request.intent.slots.directmessageusername.value;
-			const userName = helperFunctions.replaceWhitespacesDots(userNameData);
 
 			const headers = await helperFunctions.login(accessToken);
+			const userName = await helperFunctions.resolveUsername(userNameData, headers)
 			const roomid = await helperFunctions.createDMSession(userName, headers);
 			const speechText = await helperFunctions.postDirectMessage(message, roomid, headers);
 			let repromptText = ri('GENERIC_REPROMPT');
@@ -1756,12 +1756,13 @@ const PostEmojiDirectMessageIntentHandler = {
 
 			const messageData = handlerInput.requestEnvelope.request.intent.slots.directmessage.value;
 			const userNameData = handlerInput.requestEnvelope.request.intent.slots.directmessageusername.value;
-			const userName = helperFunctions.replaceWhitespacesDots(userNameData);
+			
 			const emojiData = handlerInput.requestEnvelope.request.intent.slots.directmessageemojiname.value;
 			const emoji = helperFunctions.emojiTranslateFunc(emojiData);
 			const message = messageData + emoji;
 
 			const headers = await helperFunctions.login(accessToken);
+			const userName = await helperFunctions.resolveUsername(userNameData, headers)
 			const roomid = await helperFunctions.createDMSession(userName, headers);
 			const speechText = await helperFunctions.postDirectMessage(message, roomid, headers);
 			let repromptText = ri('GENERIC_REPROMPT');

--- a/lambda/custom/package-lock.json
+++ b/lambda/custom/package-lock.json
@@ -1766,6 +1766,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "string-similarity": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.1.tgz",
+      "integrity": "sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw=="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",

--- a/lambda/custom/package.json
+++ b/lambda/custom/package.json
@@ -17,7 +17,8 @@
     "axios": "^0.18.1",
     "circular-json": "^0.5.9",
     "moji-translate": "1.0.8",
-    "remove-whitespace": "1.1.0"
+    "remove-whitespace": "1.1.0",
+    "string-similarity": "^4.0.1"
   },
   "devDependencies": {
     "@rocket.chat/eslint-config": "^0.2.0",


### PR DESCRIPTION
Closes: #78 
Currently the direct message intents work only if the username of the recipient is of the form `firstname.lastname`.
The new method uses a `string-similarity` npm module to find the username from the lislt of usernames retrieved using `/api/v1/users.list` endpoint which closely matches the invocation.
Therefore `busy kid nineteen` will get resolved to `bizykid19`, `virus thirty four` will get resolved to `virus34`, etc.
With this method there are no constraints to the format of username.
Additionally a check is being done to ensure that a wrong username doesn't get picked
```
if(username.rating >= 0.3) return username.target
````
