### PR TITLE
[Improvement] responding with only essential messages

### DIFF
--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -249,10 +249,20 @@ const getLastMessageType = async (channelName, headers) =>
 	.then((res) => res.data)
 	.then((res) => {
 		if (res.success === true) {
-			return ri('GET_LAST_MESSAGE_FROM_CHANNEL.SUCCESS', {
-				name: res.messages[0].u.username,
-				message: res.messages[0].msg,
-			});
+			for (let i = 0; i <= res.messages.length; i++) {
+				if(res.messages[i] && !res.messages[i].hasOwnProperty('t')){
+					return ri('GET_LAST_MESSAGE_FROM_CHANNEL.SUCCESS', {
+						name: res.messages[i].u.username,
+						message: res.messages[i].msg,
+					});
+				}
+				else if(res.messages[i].t == "room_changed_announcement"){
+					return ri('GET_LAST_MESSAGE_FROM_CHANNEL.SUCCESS', {
+						name: res.messages[i].u.username,
+						message: res.messages[i].msg,
+					});
+				}
+			}
 		} else {
 			return ri('GET_LAST_MESSAGE_FROM_CHANNEL.ERROR', {
 				channelName,
@@ -337,14 +347,20 @@ const channelUnreadMessages = async (channelName, unreadCount, headers) =>
 				const msgs = [];
 
 				for (let i = 0; i <= unreadCount - 1; i++) {
-					msgs.push(`${res.messages[i].u.username} says, ${res.messages[i].msg} <break time="0.7s"/> `);
+					if(res.messages[i] && !res.messages[i].hasOwnProperty('t')){
+						msgs.push(`${res.messages[i].u.username} says, ${res.messages[i].msg} <break time="0.7s"/> `);
+					} 
+					else if(res.messages[i].t == "room_changed_announcement"){
+						msgs.push(`${res.messages[i].u.username} announced, ${res.messages[i].msg} <break time="0.7s"/> `)
+					}
 				}
 
 				var responseString = msgs.join(', ');
+				var trueUnreadCount = msgs.length;
 
 				var finalMsg = ri('GET_UNREAD_MESSAGES_FROM_CHANNEL.MESSAGE', {
 					respString: responseString,
-					unread: unreadCount
+					unread: trueUnreadCount
 				});
 
 				return finalMsg;


### PR DESCRIPTION
Fixes: #84 
Currently intents such as read unread messages and read last message, performs the operations without checking the type of message, due to which non-essential messages such as user leaving or user getting added to the group are also read.
This patch introduces a check for the type of message before returning the value.
The channel.messages endpoint returns an array of messages where every message is an object with a property named 't' which represents the type of message.
Eg:
```
"t": "room_changed_announcement"
"t": "room_changed_topic"
"t": "au" (which stands for added user)
"t": "ul" (which stands for user left)
```

So for a normal message this property is undefined(does not exist in the object)
This patch returns the message for reading only if it's a normal message or if it's an announcement, all other messages are ignored.
Affected Intents:
`ReadUnreadsIntent`
`GetLastMessageFromChannelIntent`