### PR TITLE
[New] read unread mentions form channel intent

### DIFF
--- a/SampleUtterances.md
+++ b/SampleUtterances.md
@@ -404,6 +404,14 @@ Spainish
 ```
 Alexa, Leer Mis Mensajes No Leídos De CHANNELNAME
 ```
+-   **Read Unread Mentions From A Channel**
+
+English
+
+```
+Alexa, Read unread mentions from CHANNELNAME
+```
+
 -   **Post Message In A Private Channel**
 
 English

--- a/lambda/custom/apiEndpoints.js
+++ b/lambda/custom/apiEndpoints.js
@@ -35,4 +35,6 @@ module.exports = {
 	groupmessageurl: `${ serverurl }/api/v1/groups.messages?roomId=`,
 	groupcounterurl: `${ serverurl }/api/v1/groups.counters?roomId=`,
 	createimurl: `${ serverurl }/api/v1/im.create`,
+	channelcountersurl: `${serverurl}/api/v1/channels.counters`,
+	getmentionedmessagesurl: `${serverurl}/api/v1/chat.getMentionedMessages`
 };

--- a/lambda/custom/resources/en-IN.json
+++ b/lambda/custom/resources/en-IN.json
@@ -96,6 +96,13 @@
         "ERROR": "Sorry, I couldn't archive this channel right now.",
         "ERROR_NOT_FOUND": "Sorry, I couldn't archive channel {channelName} right now."
     },
+    "READ_UNREAD_MENTIONS_FROM_CHANNEL":{
+        "MESSAGE": "You have {userMentions} mentions <break time='1s'/> {finalMessage} <break time='0.7s'/>",
+        "AUTH_ERROR": "Sorry you are currently signed out, please use the companion app to authenticate.",
+        "NO_MENTIONS": "You Don't Have Any Mentions in this channel.",
+        "ERROR": "Sorry, I couldn't perform this request.",
+        "ERROR_NOT_FOUND": "Sorry, the channel does not exist. Please try again with different name."
+    },
     "AUDIO_NO_SUPPORT": "Sorry, this skill doesn't support that feature.",
     "GENERIC_REPROMPT": "Anything else I can help you with?"
 }

--- a/lambda/custom/resources/en-US.json
+++ b/lambda/custom/resources/en-US.json
@@ -96,6 +96,13 @@
         "ERROR": "Sorry, I couldn't archive this channel right now.",
         "ERROR_NOT_FOUND": "Sorry, I couldn't archive channel {channelName} right now."
     },
+    "READ_UNREAD_MENTIONS_FROM_CHANNEL":{
+        "MESSAGE": "You have {userMentions} mentions <break time='1s'/> {finalMessage} <break time='0.7s'/>",
+        "AUTH_ERROR": "Sorry you are currently signed out, please use the companion app to authenticate.",
+        "NO_MENTIONS": "You Don't Have Any Mentions in this channel.",
+        "ERROR": "Sorry, I couldn't perform this request.",
+        "ERROR_NOT_FOUND": "Sorry, the channel does not exist. Please try again with different name."
+    },
     "AUDIO_NO_SUPPORT": "Sorry, this skill doesn't support that feature.",
     "GENERIC_REPROMPT": "Anything else I can help you with?"
 }

--- a/models/en-IN.json
+++ b/models/en-IN.json
@@ -478,7 +478,26 @@
                 {
                     "name": "AMAZON.ScrollUpIntent",
                     "samples": []
-                }
+                },
+                {
+                    "name": "ReadUnreadMentionsIntent",
+                    "slots": [
+                      {
+                        "name": "channel",
+                        "type": "AMAZON.SearchQuery",
+                        "samples": [
+                          "from channel {channel}",
+                          "from {channel}",
+                          "{channel}"
+                        ]
+                      }
+                    ],
+                    "samples": [
+                      "read unread mentions from channel {channel}",
+                      "read unread mentions from {channel}",
+                      "read unread mentions"
+                    ]
+                  }
             ],
             "types": [
                 {
@@ -1860,6 +1879,23 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "ReadUnreadMentionsIntent",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                      {
+                        "name": "channel",
+                        "type": "AMAZON.SearchQuery",
+                        "elicitationRequired": true,
+                        "confirmationRequired": false,
+                        "prompts": {
+                          "elicitation": "Elicit.Slot.139759819241.55115713833"
+                        }
+                      }
+                    ],
+                    "delegationStrategy": "SKILL_RESPONSE"
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1980,6 +2016,15 @@
                         "type": "PlainText",
                         "value": "Alright, go on"
                     }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.139759819241.55115713833",
+                "variations": [
+                  {
+                    "type": "PlainText",
+                    "value": "Which channel do want the unread mentions from?"
+                  }
                 ]
             }
         ]

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -478,7 +478,26 @@
                 {
                     "name": "AMAZON.ScrollUpIntent",
                     "samples": []
-                }
+                },
+                {
+                    "name": "ReadUnreadMentionsIntent",
+                    "slots": [
+                      {
+                        "name": "channel",
+                        "type": "AMAZON.SearchQuery",
+                        "samples": [
+                          "from channel {channel}",
+                          "from {channel}",
+                          "{channel}"
+                        ]
+                      }
+                    ],
+                    "samples": [
+                      "read unread mentions from channel {channel}",
+                      "read unread mentions from {channel}",
+                      "read unread mentions"
+                    ]
+                  }
             ],
             "types": [
                 {
@@ -1860,6 +1879,23 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "ReadUnreadMentionsIntent",
+                    "confirmationRequired": false,
+                    "prompts": {},
+                    "slots": [
+                      {
+                        "name": "channel",
+                        "type": "AMAZON.SearchQuery",
+                        "elicitationRequired": true,
+                        "confirmationRequired": false,
+                        "prompts": {
+                          "elicitation": "Elicit.Slot.139759819241.55115713833"
+                        }
+                      }
+                    ],
+                    "delegationStrategy": "SKILL_RESPONSE"
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1980,6 +2016,15 @@
                         "type": "PlainText",
                         "value": "Alright, go on"
                     }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.139759819241.55115713833",
+                "variations": [
+                  {
+                    "type": "PlainText",
+                    "value": "Which channel do want the unread mentions from?"
+                  }
                 ]
             }
         ]


### PR DESCRIPTION
This intent will allow the users to read unread messages in which the user was mentioned from a channel.

Example Conversation Flow:
* **User**: Read unread mentions from {channel name}
* **Alexa**: You have 2 unread mentions, {name} says {message}, {name} says {message}