### PR TITLE
[New] acknowledge mentions intent

### DIFF
--- a/lambda/custom/apiEndpoints.js
+++ b/lambda/custom/apiEndpoints.js
@@ -35,4 +35,7 @@ module.exports = {
 	groupmessageurl: `${ serverurl }/api/v1/groups.messages?roomId=`,
 	groupcounterurl: `${ serverurl }/api/v1/groups.counters?roomId=`,
 	createimurl: `${ serverurl }/api/v1/im.create`,
+	channelcountersurl: `${serverurl}/api/v1/channels.counters`,
+	getmentionedmessagesurl: `${serverurl}/api/v1/chat.getMentionedMessages`,
+	reacttomessageurl: `${serverurl}/api/v1/chat.react`
 };

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -1779,6 +1779,96 @@ const PostEmojiDirectMessageIntentHandler = {
 	},
 };
 
+const StartedAcknowledgeUnreadMentionsIntentHandler = {
+	canHandle(handlerInput) {
+	  	return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
+			handlerInput.requestEnvelope.request.intent.name === 'AcknowledgeUnreadMentionsIntent' &&
+			handlerInput.requestEnvelope.request.dialogState === 'STARTED';
+	},
+	handle(handlerInput) {
+	  const currentIntent = handlerInput.requestEnvelope.request.intent;
+	  return handlerInput.responseBuilder
+		.addDelegateDirective(currentIntent)
+		.getResponse();
+	},
+};
+  
+const InProgressAcknowledgeUnreadMentionsIntentHandler = {
+	canHandle(handlerInput) {
+	  	return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
+			handlerInput.requestEnvelope.request.intent.name === 'AcknowledgeUnreadMentionsIntent' &&
+			handlerInput.requestEnvelope.request.dialogState === 'IN_PROGRESS' &&
+			handlerInput.requestEnvelope.request.intent.confirmationStatus !== 'DENIED';
+	},
+	handle(handlerInput) {
+	  const currentIntent = handlerInput.requestEnvelope.request.intent;
+	  return handlerInput.responseBuilder
+		.addDelegateDirective(currentIntent)
+		.getResponse();
+	},
+};
+  
+const DeniedAcknowledgeUnreadMentionsIntentHandler = {
+	canHandle(handlerInput) {
+		return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
+			handlerInput.requestEnvelope.request.intent.name === 'AcknowledgeUnreadMentionsIntent' &&
+			handlerInput.requestEnvelope.request.dialogState === 'IN_PROGRESS' &&
+			handlerInput.requestEnvelope.request.intent.confirmationStatus === 'DENIED';
+	},
+	  handle(handlerInput) {
+		  let speechText = ri('GET_UNREAD_MENTIONS_FROM_CHANNEL.DENIED');
+  
+		  return handlerInput.jrb
+			.speak(speechText)
+			.addDelegateDirective({
+			  name: 'AcknowledgeUnreadMentionsIntent',
+			  confirmationStatus: 'NONE',
+			  slots: {
+				  "channel": {
+					  "name": "channel",
+					  "confirmationStatus": "NONE"
+				  }
+			  }
+			})
+			.getResponse();
+	  },
+  };
+	
+const AcknowledgeUnreadMentionsIntentHandler = {
+	canHandle(handlerInput) {
+		return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
+			handlerInput.requestEnvelope.request.intent.name === 'AcknowledgeUnreadMentionsIntent'
+			&& handlerInput.requestEnvelope.request.dialogState === 'COMPLETED'
+			&& handlerInput.requestEnvelope.request.intent.confirmationStatus === 'CONFIRMED';
+	},
+	async handle(handlerInput) {
+		try {
+			const {
+				accessToken
+			} = handlerInput.requestEnvelope.context.System.user;
+
+			const channelNameData = handlerInput.requestEnvelope.request.intent.slots.channel.value;
+			const channelName = helperFunctions.replaceWhitespacesFunc(channelNameData);
+
+			const headers = await helperFunctions.login(accessToken);
+			const roomid = await helperFunctions.getRoomId(channelName, headers);
+			const speechText = await helperFunctions.acknowledgeUnreadMentions(roomid, headers);
+			let repromptText = ri('GENERIC_REPROMPT');
+
+
+			return handlerInput.jrb
+			.speak(speechText)
+			.speak(repromptText)
+			.reprompt(repromptText)
+			.getResponse();
+
+
+		} catch (error) {
+			console.error(error);
+		}
+	},
+};
+
 const HelpIntentHandler = {
 	canHandle(handlerInput) {
 		return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
@@ -2026,6 +2116,10 @@ exports.handler = skillBuilder
 		ProactiveEventHandler,
 		LaunchRequestHandler,
 		ChangeNotificationSettingsIntentHandler,
+		StartedAcknowledgeUnreadMentionsIntentHandler,
+		InProgressAcknowledgeUnreadMentionsIntentHandler,
+		DeniedAcknowledgeUnreadMentionsIntentHandler,
+		AcknowledgeUnreadMentionsIntentHandler,
 		StartedCreateChannelIntentHandler,
 		InProgressCreateChannelIntentHandler,
 		DeniedCreateChannelIntentHandler,

--- a/lambda/custom/resources/en-IN.json
+++ b/lambda/custom/resources/en-IN.json
@@ -96,6 +96,13 @@
         "ERROR": "Sorry, I couldn't archive this channel right now.",
         "ERROR_NOT_FOUND": "Sorry, I couldn't archive channel {channelName} right now."
     },
+    "ACKNOWLEDGE_UNREAD_MENTIONS_CHANNEL": {
+        "SUCCESS": "I've acknowledged your mentions.",
+        "AUTH_ERROR": "Sorry you are currently signed out, please use the companion app to authenticate.",
+        "NO_MENTIONS": "You Don't Have Any Mentions in this channel.",
+        "ERROR": "Sorry, I couldn't acknowledge your mentions.",
+        "ERROR_NOT_FOUND": "Sorry, the channel does not exist. Please try again with a different name."
+    },
     "AUDIO_NO_SUPPORT": "Sorry, this skill doesn't support that feature.",
     "GENERIC_REPROMPT": "Anything else I can help you with?"
 }

--- a/lambda/custom/resources/en-US.json
+++ b/lambda/custom/resources/en-US.json
@@ -96,6 +96,13 @@
         "ERROR": "Sorry, I couldn't archive this channel right now.",
         "ERROR_NOT_FOUND": "Sorry, I couldn't archive channel {channelName} right now."
     },
+    "ACKNOWLEDGE_UNREAD_MENTIONS_CHANNEL": {
+        "SUCCESS": "I've acknowledged your mentions.",
+        "AUTH_ERROR": "Sorry you are currently signed out, please use the companion app to authenticate.",
+        "NO_MENTIONS": "You Don't Have Any Mentions in this channel.",
+        "ERROR": "Sorry, I couldn't acknowledge your mentions.",
+        "ERROR_NOT_FOUND": "Sorry, the channel does not exist. Please try again with a different name."
+    },
     "AUDIO_NO_SUPPORT": "Sorry, this skill doesn't support that feature.",
     "GENERIC_REPROMPT": "Anything else I can help you with?"
 }

--- a/models/en-IN.json
+++ b/models/en-IN.json
@@ -478,6 +478,27 @@
                 {
                     "name": "AMAZON.ScrollUpIntent",
                     "samples": []
+                },
+                {
+                    "name": "AcknowledgeUnreadMentionsIntent",
+                    "slots": [
+                      {
+                        "name": "channel",
+                        "type": "AMAZON.SearchQuery",
+                        "samples": [
+                          "to channel {channel}",
+                          "to {channel}",
+                          "{channel}"
+                        ]
+                      }
+                    ],
+                    "samples": [
+                      "react to mentions in channel {channel}",
+                      "react to mentions in {channel}",
+                      "react to unread mentions",
+                      "react to mentions",
+                      "acknowledge mentions"
+                    ]
                 }
             ],
             "types": [
@@ -1860,6 +1881,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "AcknowledgeUnreadMentionsIntent",
+                    "confirmationRequired": true,
+                    "prompts": {
+                      "confirmation": "Confirm.Intent.1262531860967"
+                    },
+                    "slots": [
+                      {
+                        "name": "channel",
+                        "type": "AMAZON.SearchQuery",
+                        "elicitationRequired": true,
+                        "confirmationRequired": false,
+                        "prompts": {
+                          "elicitation": "Elicit.Slot.1262531860967.460974451400"
+                        }
+                      }
+                    ]
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1979,6 +2018,24 @@
                     {
                         "type": "PlainText",
                         "value": "Alright, go on"
+                    }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.1262531860967.460974451400",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "Which channel mentions would you like to react to?"
+                    }
+                ]
+              },
+              {
+                "id": "Confirm.Intent.1262531860967",
+                "variations": [
+                    {
+                        "type": "PlainText",
+                        "value": "You want to react to mentions in {channel} , is that correct?"
                     }
                 ]
             }

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -478,6 +478,27 @@
                 {
                     "name": "AMAZON.ScrollUpIntent",
                     "samples": []
+                },
+                {
+                    "name": "AcknowledgeUnreadMentionsIntent",
+                    "slots": [
+                      {
+                        "name": "channel",
+                        "type": "AMAZON.SearchQuery",
+                        "samples": [
+                          "to channel {channel}",
+                          "to {channel}",
+                          "{channel}"
+                        ]
+                      }
+                    ],
+                    "samples": [
+                      "react to mentions in channel {channel}",
+                      "react to mentions in {channel}",
+                      "react to unread mentions",
+                      "react to mentions",
+                      "acknowledge mentions"
+                    ]
                 }
             ],
             "types": [
@@ -1860,6 +1881,25 @@
                             }
                         }
                     ]
+                },
+                {
+                    "name": "AcknowledgeUnreadMentionsIntent",
+                    "confirmationRequired": true,
+                    "prompts": {
+                      "confirmation": "Confirm.Intent.693640581309"
+                    },
+                    "slots": [
+                      {
+                        "name": "channel",
+                        "type": "AMAZON.SearchQuery",
+                        "elicitationRequired": true,
+                        "confirmationRequired": false,
+                        "prompts": {
+                          "elicitation": "Elicit.Slot.693640581309.791820660757"
+                        }
+                      }
+                    ],
+                    "delegationStrategy": "SKILL_RESPONSE"
                 }
             ],
             "delegationStrategy": "ALWAYS"
@@ -1980,6 +2020,24 @@
                         "type": "PlainText",
                         "value": "Alright, go on"
                     }
+                ]
+            },
+            {
+                "id": "Elicit.Slot.693640581309.791820660757",
+                "variations": [
+                  {
+                    "type": "PlainText",
+                    "value": "Which channel mentions would you like to react to?"
+                  }
+                ]
+              },
+              {
+                "id": "Confirm.Intent.693640581309",
+                "variations": [
+                  {
+                    "type": "PlainText",
+                    "value": "You want to react to mentions in {channel} , is that correct?"
+                  }
                 ]
             }
         ]


### PR DESCRIPTION
This intent will let the users react to unread messages in which the user was mentioned in a channel.

Conversation flow:
* **User**: Acknowledge mentions in CHANNELNAME
* **Alexa**: You want to react to mentions in CHANNELNAME , is that correct?
* **User**: Yes
* **Alexa**: I've acknowledged your mentions.

Result: 
![acknowledge](https://user-images.githubusercontent.com/47289788/79689448-848df580-8272-11ea-9965-f12b06577421.png)

This intent is supposed to be a follow up for read unread mentions from a channel Intent #95 .
Therefore, the user first requests alexa to read unread mentioned messages and then, if he wishes to, he can also acknowledge them.
