### PR TITLE
[New] get all unread mentions intent

### DIFF
--- a/SampleUtterances.md
+++ b/SampleUtterances.md
@@ -404,6 +404,15 @@ Spainish
 ```
 Alexa, Leer Mis Mensajes No Leídos De CHANNELNAME
 ```
+
+-   **Read All Unread Mentions From Channels**
+
+English
+
+```
+Alexa, get all unread mentions
+```
+
 -   **Post Message In A Private Channel**
 
 English

--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -887,6 +887,35 @@ const postDirectMessage = async (message, roomid, headers) =>
 		return ri('POST_MESSAGE.ERROR');
 	});
 
+const getAllUnreadMentions = async (headers) => {
+	try{
+		let response = await axios.get(apiEndpoints.channellisturl, {
+			headers
+		}).then((res) => res.data)
+		let finalMessage = ""
+		for (let i = 0; i < response.channels.length; i++){
+			channelName = response.channels[i].name
+			counters = await axios.get(`${apiEndpoints.counterurl}${channelName}`, {
+				headers
+			}).then((res) => res.data)
+				
+			if(counters.userMentions == 0) continue
+			
+			finalMessage += `${counters.userMentions} mentions in ${channelName}, `
+		}
+		if (finalMessage == "") return ri('GET_ALL_UNREAD_MENTIONS.NO_MENTIONS')
+		return ri('GET_ALL_UNREAD_MENTIONS.MESSAGE', {finalMessage})
+	}catch(err) {
+		console.log(err.message)
+		if (err.response.status === 401) {
+			return ri('GET_UNREAD_MENTIONS_FROM_CHANNEL.AUTH_ERROR')
+		} else {
+			return ri('GET_ALL_UNREAD_MENTIONS.ERROR')
+		}
+	}
+}
+
+	
 
 // Module Export of Functions
 
@@ -926,3 +955,4 @@ module.exports.groupUnreadMessages = groupUnreadMessages;
 module.exports.createDMSession = createDMSession;
 module.exports.postDirectMessage = postDirectMessage;
 module.exports.getLastMessageType = getLastMessageType;
+module.exports.getAllUnreadMentions = getAllUnreadMentions;

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -1477,6 +1477,33 @@ const CreateGrouplIntentHandler = {
 	},
 };
 
+const GetAllUnreadMentionsIntentHandler = {
+	canHandle(handlerInput) {
+		return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
+			handlerInput.requestEnvelope.request.intent.name === 'GetAllUnreadMentionsIntent';
+	},
+	async handle(handlerInput) {
+		try {
+			const {
+				accessToken
+			} = handlerInput.requestEnvelope.context.System.user;
+
+			const headers = await helperFunctions.login(accessToken);
+			const speechText = await helperFunctions.getAllUnreadMentions(headers);
+			let repromptText = ri('GENERIC_REPROMPT');
+
+			return handlerInput.jrb
+				.speak(speechText)
+				.speak(repromptText)
+				.reprompt(repromptText)
+				.getResponse();
+		} catch (error) {
+			console.error(error);
+		}
+	},
+};
+
+
 const DeleteGroupIntentHandler = {
 	canHandle(handlerInput) {
 		return handlerInput.requestEnvelope.request.type === 'IntentRequest' &&
@@ -2051,6 +2078,7 @@ exports.handler = skillBuilder
 		ArchiveChannelIntentHandler,
 		GetUnreadMessagesIntentHandler,
 		CreateGrouplIntentHandler,
+		GetAllUnreadMentionsIntentHandler,
 		DeleteGroupIntentHandler,
 		MakeGroupModeratorIntentHandler,
 		MakeGroupOwnerIntentHandler,

--- a/lambda/custom/resources/en-IN.json
+++ b/lambda/custom/resources/en-IN.json
@@ -96,6 +96,12 @@
         "ERROR": "Sorry, I couldn't archive this channel right now.",
         "ERROR_NOT_FOUND": "Sorry, I couldn't archive channel {channelName} right now."
     },
+    "GET_ALL_UNREAD_MENTIONS": {
+        "MESSAGE": "You have, {finalMessage}.",
+        "AUTH_ERROR": "Sorry you are currently signed out , please use the companion app to authenticate.",
+        "NO_MENTIONS": "You don't have any unread mentions.",
+        "ERROR": "Sorry, I couldn't perform this request."
+    },
     "AUDIO_NO_SUPPORT": "Sorry, this skill doesn't support that feature.",
     "GENERIC_REPROMPT": "Anything else I can help you with?"
 }

--- a/lambda/custom/resources/en-US.json
+++ b/lambda/custom/resources/en-US.json
@@ -96,6 +96,12 @@
         "ERROR": "Sorry, I couldn't archive this channel right now.",
         "ERROR_NOT_FOUND": "Sorry, I couldn't archive channel {channelName} right now."
     },
+    "GET_ALL_UNREAD_MENTIONS": {
+        "MESSAGE": "You have, {finalMessage}.",
+        "AUTH_ERROR": "Sorry you are currently signed out , please use the companion app to authenticate.",
+        "NO_MENTIONS": "You don't have any unread mentions.",
+        "ERROR": "Sorry, I couldn't perform this request."
+    },
     "AUDIO_NO_SUPPORT": "Sorry, this skill doesn't support that feature.",
     "GENERIC_REPROMPT": "Anything else I can help you with?"
 }

--- a/models/en-IN.json
+++ b/models/en-IN.json
@@ -478,6 +478,15 @@
                 {
                     "name": "AMAZON.ScrollUpIntent",
                     "samples": []
+                },
+                {
+                    "name": "GetAllUnreadMentionsIntent",
+                    "slots": [],
+                    "samples": [
+                      "all mentions",
+                      "all unread mentions",
+                      "get all unread mentions"
+                    ]
                 }
             ],
             "types": [

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -478,6 +478,15 @@
                 {
                     "name": "AMAZON.ScrollUpIntent",
                     "samples": []
+                },
+                {
+                    "name": "GetAllUnreadMentionsIntent",
+                    "slots": [],
+                    "samples": [
+                      "all mentions",
+                      "all unread mentions",
+                      "get all unread mentions"
+                    ]
                 }
             ],
             "types": [


### PR DESCRIPTION
On invoking this intent the users will get the total number of unread mentions channels-wise as a reponse.

Conversation Flow
* **User**: get all mentions
* **Alexa**: You have 2 mentions in CHANNELNAME, and 1 mentions in CHANNELNAME.