### PR TITLE
[Improvement] faster group unread messages intent

### DIFF
--- a/lambda/custom/helperFunctions.js
+++ b/lambda/custom/helperFunctions.js
@@ -804,33 +804,33 @@ const getGroupUnreadCounter = async (roomid, headers) =>
 		console.log(err.message);
 	});
 
-const groupUnreadMessages = async (channelName, roomid, unreadCount, headers) =>
-	await axios
-	.get(`${ apiEndpoints.groupmessageurl }${ roomid }`, {
+const groupUnreadMessages = async (channelName, roomid, unreadCount, headers) => {
+
+	if(unreadCount == 0) return ri('GET_UNREAD_MESSAGES_FROM_CHANNEL.NO_MESSAGE');
+
+	return await axios
+	.get(`${ apiEndpoints.groupmessageurl }${ roomid }&count=${unreadCount}`, {
 		headers
 	})
 	.then((res) => res.data)
 	.then((res) => {
 		if (res.success === true) {
 
-			if (unreadCount == 0) {
-				return ri('GET_UNREAD_MESSAGES_FROM_CHANNEL.NO_MESSAGE');
-			} else {
-				const msgs = [];
+			const msgs = [];
 
-				for (let i = 0; i <= unreadCount - 1; i++) {
-					msgs.push(`${res.messages[i].u.username} says, ${res.messages[i].msg} <break time="0.7s"/> `);
-				}
-
-				var responseString = msgs.join('  ');
-
-				var finalMsg = ri('GET_UNREAD_MESSAGES_FROM_CHANNEL.MESSAGE', {
-					respString: responseString,
-					unread: unreadCount
-				});
-
-				return finalMsg;
+			for (let i = 0; i <= unreadCount - 1; i++) {
+				msgs.push(`${res.messages[i].u.username} says, ${res.messages[i].msg} <break time="0.7s"/> `);
 			}
+
+			var responseString = msgs.join('  ');
+
+			var finalMsg = ri('GET_UNREAD_MESSAGES_FROM_CHANNEL.MESSAGE', {
+				respString: responseString,
+				unread: unreadCount
+			});
+
+			return finalMsg;
+			
 		} else {
 			return ri('GET_UNREAD_MESSAGES_FROM_CHANNEL.ERROR');
 		}
@@ -848,6 +848,7 @@ const groupUnreadMessages = async (channelName, roomid, unreadCount, headers) =>
 			return ri('GET_UNREAD_MESSAGES_FROM_CHANNEL.ERROR');
 		}
 	});
+}
 
 const createDMSession = async (userName, headers) =>
 	await axios


### PR DESCRIPTION
Currently the `ReadGroupUnreadsIntent` which reads unread messages from a private channel makes a call to `/api/v1/groups.counters` endpoint which returns the number of unread messages in a group and then `/api/v1/groups.messages?roomId={roomId}` API endpoint which returns all the messages from the private channel (max: 50 messages) and then selects the top unreads count number of messages and reads it out.

In this PR this intent makes an API request to `/api/v1/groups.messages?roomId={roomId}&count={unreads count}` endpoint which responds with only the unread messages (because of the count parameter used), then reads it out.

Therefore, if there are 3 unreads in a channel this endpoint responds with only 3 messages instead of 50(before improvement) and thus making this intent significantly faster.