### PR TITLE
[Improvement] adding intent confirmation to post long message

### DIFF
--- a/lambda/custom/handlers/General/NoIntentHandler.js
+++ b/lambda/custom/handlers/General/NoIntentHandler.js
@@ -1,8 +1,4 @@
 const { ri } = require('@jargon/alexa-skill-sdk');
-const { login, postMessage } = require('../../helperFunctions');
-const { supportsAPL } = require('../../utils');
-const titleMessageBoxTemplate = require('../../APL/templates/titleMessageBoxTemplate');
-
 
 const NoIntentHandler = {
 	canHandle(handlerInput) {
@@ -15,44 +11,21 @@ const NoIntentHandler = {
 			const sessionAttributes = attributesManager.getSessionAttributes() || {};
 
 			if (sessionAttributes.postLongMessageIntentOnProgress) {
-				delete sessionAttributes.postLongMessageIntentOnProgress;
-				delete sessionAttributes.channelConfirm;
-				const {
-					accessToken,
-				} = handlerInput.requestEnvelope.context.System.user;
 
-
-
-				const { channelName } = sessionAttributes;
-				const { message } = sessionAttributes;
-
-				delete sessionAttributes.channelName;
-				delete sessionAttributes.message;
-
-				const headers = await login(accessToken);
-				const speechText = await postMessage(channelName, message, headers);
-				const repromptText = ri('GENERIC_REPROMPT');
-
-
-				if (supportsAPL(handlerInput)) {
-					const data = {
-						title: handlerInput.translate('POST_MESSAGE.APL_SUCCESS', { channelName }),
-						message,
-					};
-
+				if (!sessionAttributes.postLongMessageConfirmation) {
+					sessionAttributes.postLongMessageConfirmation = true;
+					const speechText = ri('POST_MESSAGE.POST_LONG_MESSAGE_CONFIRMATION', { longmessage: sessionAttributes.message, channelName: sessionAttributes.channelName });
 					return handlerInput.jrb
 						.speak(speechText)
-						.speak(repromptText)
-						.reprompt(repromptText)
-						.addDirective(titleMessageBoxTemplate(data))
+						.reprompt(speechText)
 						.getResponse();
-
 				} else {
+					const speechText = ri('POST_MESSAGE.DENIED');
+					const repromptText = ri('GENERIC_REPROMPT');
 					return handlerInput.jrb
 						.speak(speechText)
 						.speak(repromptText)
 						.reprompt(repromptText)
-						.withSimpleCard(ri('POST_MESSAGE.CARD_TITLE'), speechText)
 						.getResponse();
 				}
 			} else {

--- a/lambda/custom/handlers/General/NoIntentHandler.js
+++ b/lambda/custom/handlers/General/NoIntentHandler.js
@@ -20,6 +20,12 @@ const NoIntentHandler = {
 						.reprompt(speechText)
 						.getResponse();
 				} else {
+					delete sessionAttributes.postLongMessageConfirmation;
+					delete sessionAttributes.postLongMessageIntentOnProgress;
+					delete sessionAttributes.channelConfirm;
+					delete sessionAttributes.channelName;
+					delete sessionAttributes.message;
+
 					const speechText = ri('POST_MESSAGE.DENIED');
 					const repromptText = ri('GENERIC_REPROMPT');
 					return handlerInput.jrb

--- a/lambda/custom/handlers/General/YesIntentHandler.js
+++ b/lambda/custom/handlers/General/YesIntentHandler.js
@@ -78,6 +78,12 @@ const YesIntentHandler = {
 					},
 				})
 				.getResponse();
+		} else {
+			const speechText = ri('YES_PROMPT');
+			return handlerInput.jrb
+				.speak(speechText)
+				.reprompt(speechText)
+				.getResponse();
 		}
 
 

--- a/lambda/custom/resources/en-US.json
+++ b/lambda/custom/resources/en-US.json
@@ -120,5 +120,6 @@
     },
     "AUTH_ERROR":"Sorry you are currently signed out , please use the companion app to authenticate.",
     "AUDIO_NO_SUPPORT": "Sorry, this skill doesn't support that feature.",
-    "GENERIC_REPROMPT": "Anything else I can help you with?"
+    "GENERIC_REPROMPT": "Anything else I can help you with?",
+    "YES_PROMPT": "What would you like to do?"
 }

--- a/lambda/custom/resources/en-US.json
+++ b/lambda/custom/resources/en-US.json
@@ -39,6 +39,7 @@
         "SIMILAR_USERS": "There are multiple users with similar username. Please tell the serial number of desired user. {usernames}.",
         "CONFIRM_MORE": "Okay, go on.",
         "CONFIRM_MORE_REPROMPT": "Please continue your message.",
+        "POST_LONG_MESSAGE_CONFIRMATION": "You want to send, {longmessage}, to channel {channelName}, is that correct?",
         "AUTH_ERROR": "Sorry you are currently signed out , please use the companion app to authenticate ",
         "CARD_TITLE": "Post A Message",
         "ERROR": "Sorry, I couldn't send your message right now.",


### PR DESCRIPTION
This PR adds intent confirmation to the post long message intent.
This is achieved using a session attribute which is used to determine is the yes/no intent was called during intent confirmation.
If yes/no intent were called during intent confirmation, then message sent/message denied response is given respectively.